### PR TITLE
Fix ExternalInterface crashing

### DIFF
--- a/ayesaac/services/common/service_base.py
+++ b/ayesaac/services/common/service_base.py
@@ -25,6 +25,3 @@ class ServiceBase(object):
 
     def run(self) -> None:
         self.queue_manager.start_consuming(self.__class__.__name__, self.callback)
-
-    def _update_path_done(self, body: T) -> T:
-        return body["path_done"].append(self.__class__.__name__)

--- a/ayesaac/services/external_interface/external_interface.py
+++ b/ayesaac/services/external_interface/external_interface.py
@@ -20,7 +20,7 @@ class ExternalInterface(ServiceBase):
         self.__post_init__()
 
     def callback(self, body, **_):
-        body = self._update_path_done(body)
+        body["path_done"].append(self.__class__.__name__)
 
         self.dump_output(body)
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -85,6 +85,9 @@ services:
       - type: bind
         source: ./ayesaac/services/external_interface
         target: /app/ayesaac/services/external_interface
+      - type: bind
+        source: ./output
+        target: /app/output
 
   interpreter:
     container_name: interpreter


### PR DESCRIPTION
Using the base class to update the body of the state would cause it to just be `None`. Not sure why, but it's been removed and now data is getting through! 

Additionally, the `docker-compose.yml` has been updated to allow for easier debugging. When the request reaches the ExternalInterface, it gets saved to the `output/` folder so it can be queried when called. 

There is probably a more secure way to handle this using databases, but this will do for now. **This will need addressing before deploying to production.** 