### PR TITLE
Fix web service not returning results

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -76,12 +76,8 @@ services:
       - -m
       - ayesaac.services.external_interface
     volumes:
-      - type: bind
-        source: ./ayesaac/services/external_interface
-        target: /app/ayesaac/services/external_interface
-      - type: bind
-        source: ./output
-        target: /app/output
+      - ./ayesaac/services/external_interface:/app/ayesaac/services/external_interface
+      - output_data:/app/output
 
   interpreter:
     container_name: interpreter
@@ -205,3 +201,7 @@ services:
       - "--host=0.0.0.0"
     volumes:
       - ./ayesaac/services/web:/app/ayesaac/services/web
+      - output_data:/app/output
+
+volumes:
+  output_data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -31,9 +31,7 @@ services:
       - -m
       - ayesaac.services.automatic_speech_recognition
     volumes:
-      - type: bind
-        source: ./ayesaac/services/automatic_speech_recognition
-        target: /app/ayesaac/services/automatic_speech_recognition
+      - ./ayesaac/services/automatic_speech_recognition:/app/ayesaac/services/automatic_speech_recognition
 
   camera_manager:
     container_name: camera_manager
@@ -48,9 +46,7 @@ services:
       - -m
       - ayesaac.services.camera_manager.main
     volumes:
-      - type: bind
-        source: ./ayesaac/services/camera_manager
-        target: /app/ayesaac/services/camera_manager
+      - ./ayesaac/services/camera_manager:/app/ayesaac/services/camera_manager
 
   colour_detection:
     container_name: colour_detection
@@ -65,9 +61,7 @@ services:
       - -m
       - ayesaac.services.colour_detection.main
     volumes:
-      - type: bind
-        source: ./ayesaac/services/colour_detection
-        target: /app/ayesaac/services/colour_detection
+      - ./ayesaac/services/colour_detection:/app/ayesaac/services/colour_detection
 
   external_interface:
     container_name: external_interface
@@ -102,9 +96,7 @@ services:
       - -m
       - ayesaac.services.interpreter.main
     volumes:
-      - type: bind
-        source: ./ayesaac/services/interpreter
-        target: /app/ayesaac/services/interpreter
+      - ./ayesaac/services/interpreter:/app/ayesaac/services/interpreter
 
   manager:
     container_name: manager
@@ -119,9 +111,7 @@ services:
       - -m
       - ayesaac.services.manager.main
     volumes:
-      - type: bind
-        source: ./ayesaac/services/manager
-        target: /app/ayesaac/services/manager
+      - ./ayesaac/services/manager:/app/ayesaac/services/manager
 
   natural_language_generator:
     container_name: natural_language_generator
@@ -136,9 +126,7 @@ services:
       - -m
       - ayesaac.services.natural_language_generator.main
     volumes:
-      - type: bind
-        source: ./ayesaac/services/natural_language_generator
-        target: /app/ayesaac/services/natural_language_generator
+      - ./ayesaac/services/natural_language_generator:/app/ayesaac/services/natural_language_generator
 
   natural_language_understanding:
     container_name: natural_language_understanding
@@ -153,9 +141,7 @@ services:
       - -m
       - ayesaac.services.natural_language_understanding.main
     volumes:
-      - type: bind
-        source: ./ayesaac/services/natural_language_understanding
-        target: /app/ayesaac/services/natural_language_understanding
+      - ./ayesaac/services/natural_language_understanding:/app/ayesaac/services/natural_language_understanding
 
   object_detection:
     container_name: object_detection
@@ -170,9 +156,7 @@ services:
       - -m
       - ayesaac.services.object_detection.main
     volumes:
-      - type: bind
-        source: ./ayesaac/services/object_detection
-        target: /app/ayesaac/services/object_detection
+      - ./ayesaac/services/object_detection:/app/ayesaac/services/object_detection
 
   optical_character_recognition:
     container_name: optical_character_recognition
@@ -187,9 +171,7 @@ services:
       - -m
       - ayesaac.services.optical_character_recognition.main
     volumes:
-      - type: bind
-        source: ./ayesaac/services/optical_character_recognition
-        target: /app/ayesaac/services/optical_character_recognition
+      - ./ayesaac/services/optical_character_recognition:/app/ayesaac/services/optical_character_recognition
 
   position_detection:
     container_name: position_detection
@@ -204,9 +186,7 @@ services:
       - -m
       - ayesaac.services.position_detection.main
     volumes:
-      - type: bind
-        source: ./ayesaac/services/position_detection
-        target: /app/ayesaac/services/position_detection
+      - ./ayesaac/services/position_detection:/app/ayesaac/services/position_detection
 
   web:
     container_name: web
@@ -224,6 +204,4 @@ services:
       - run
       - "--host=0.0.0.0"
     volumes:
-      - type: bind
-        source: ./ayesaac/services/web
-        target: /app/ayesaac/services/web
+      - ./ayesaac/services/web:/app/ayesaac/services/web


### PR DESCRIPTION
The output was being taken and saved within the ExternalInterface, but it wasn't being returned by the second request. 

The problem was because the web service did not also connect to the local output folder to get the results from. This is fixed by ensuring both the External Interface and the Web service send/get the output from the same location. 

To prevent data from being stored locally, "volumes" have been implemented within the docker-compose.yaml file. Therefore, the `output/` folder **will no longer contain any output data in your local repository**, but it WILL still exist within the container for each image. If you _need_ to see the generated files, you can ssh within the container while it's running and  find the files. 